### PR TITLE
#3 Not restoring room size is making errors

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -639,9 +639,14 @@ function saveData() {
         localStorage.setItem(`std-${student.id}`, JSON.stringify(student))
     })
 
-    // Save seats data
+    // Save room data
     const rows = parseInt(document.getElementById("room-row").value)
     const cols = parseInt(document.getElementById("room-col").value)
+
+    localStorage.setItem("room-rows", rows)
+    localStorage.setItem("room-cols", cols)
+
+    // Save seats data
     for (let i = 1; i <= rows; i++) {
         for (let j = 1; j <= cols; j++) {
             const seatCard = document.getElementById(`seat-${i}-${j}`)

--- a/js/main.js
+++ b/js/main.js
@@ -671,6 +671,16 @@ function restoreData() {
     // Clear students list
     student_list = []
 
+    // Restore room data
+    const rows = localStorage.getItem("room-rows")
+    const cols = localStorage.getItem("room-cols")
+
+    if (rows && cols) {
+        document.getElementById("room-row").setAttribute("value", rows)
+        document.getElementById("room-col").setAttribute("value", cols)
+    }
+    update_room()
+
     // Restore students and seats data
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i)


### PR DESCRIPTION
This pull request includes updates to the `saveData` and `restoreData` functions in the `js/main.js` file to fix the handling of room data. The key changes involve saving and restoring room configuration (rows and columns) in the `localStorage`.

Enhancements to room data handling:

* [`js/main.js`](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046L642-R649): Modified the `saveData` function to store room rows and columns in local storage.
* [`js/main.js`](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046R674-R683): Updated the `restoreData` function to retrieve room rows and columns from local storage and set them in the corresponding input fields.